### PR TITLE
Removed prettier/react from .eslintrc as it does not exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ Create a `.eslintrc` file in the project root and enter the below contents:
     "airbnb/hooks",
     "eslint:recommended",
     "prettier",
-    "prettier/react",
     "plugin:jsx-a11y/recommended"
   ],
   "parser": "babel-eslint",


### PR DESCRIPTION
In version 8.0.0 extending "prettier" is enough – it includes all the React rules as well (and rules for other plugins).
source- https://github.com/prettier/eslint-config-prettier/issues/2