### PR TITLE
Update version of babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In order to lint and format your React project automatically according to popula
 
 ```sh
 yarn add -D prettier
-yarn add -D babel-eslint
+yarn add -D @babel/eslint-parser
 npx install-peerdeps --dev eslint-config-airbnb
 yarn add -D eslint-config-prettier eslint-plugin-prettier
 ```
@@ -121,7 +121,7 @@ or You can also add a new script in the scripts section like below to install ev
 
 ```json
 scripts: {
-    "lint": "yarn add -D prettier && yarn add -D babel-eslint && npx install-peerdeps --dev eslint-config-airbnb && yarn add -D eslint-config-prettier eslint-plugin-prettier"
+    "lint": "yarn add -D prettier && yarn add -D @babel/eslint-parser && npx install-peerdeps --dev eslint-config-airbnb && yarn add -D eslint-config-prettier eslint-plugin-prettier"
 }
 ```
 
@@ -144,7 +144,7 @@ Create a `.eslintrc` file in the project root and enter the below contents:
     "prettier",
     "plugin:jsx-a11y/recommended"
   ],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 8
   },


### PR DESCRIPTION
Babel is no longer babel-eslint but currently it's @babel/eslint-parser, without these changes vscode runs into errors.