### PR TITLE
Eslint: Parsing Error Fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can use any editor but as I personally prefer VS Code. I will give some inst
 
 You need to install the below plugins:
 
-- ESLint by Dirk Baeumer
+- ESLint by Microsoft
 - Prettier - Code formatter by Prettier
 - Dracula Official Theme (optional)
 
@@ -144,7 +144,7 @@ Create a `.eslintrc` file in the project root and enter the below contents:
     "prettier",
     "plugin:jsx-a11y/recommended"
   ],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 8
   },


### PR DESCRIPTION
Parsing error: require() of ES Module *\myreact\node_modules\eslint\node_modules\eslint-scope\lib\definition.js from *\myreact\node_modules\babel-eslint\lib\require-from-eslint.js not supported. Instead change the require of definition.js in *\myreact\node_modules\babel-eslint\lib\require-from-eslint.js to a dynamic import() which is available in all CommonJS modules.eslint